### PR TITLE
Posts controller - show one, update routes added

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -35,13 +35,23 @@ router.post('/', async (req, res) => {
 });
 
 // Update route for posts
+// router.put( '/:id', async (req, res) => {
+//   try {
+//     const updatePost = await Post.findByIdAndUpdate( req.params.id, req.body );
+//     console.log(updatePost);
+//     res.status( 200 ).json( updatePost );
+//   } catch ( err ) {
+//     console.log( err );
+//     res.status( 400 ).json({ err: err.message });
+//   }
+// });
 
 // Delete route for one post
 // Need to add authentication permissions later
-router.get('/:id', async (req, res) => {
+router.delete('/:id', async (req, res) => {
   try {
-    const deletedPost = await Post.findByIdAndRemove(req.params.id);
-    res.status( 200 ).json( deletedPost );
+    const deletePost = await Post.findByIdAndRemove(req.params.id);
+    res.status( 200 ).json( deletePost );
   } catch (err) {
     console.log( err );
     res.status( 400 ).json({ err: err.message });

--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -20,6 +20,18 @@ router.get('/', async (req, res) => {
   }
 });
 
+// Show route for one post
+router.get('/:id', async (req, res) => {
+  try {
+    const onePost = await Post.findById(req.params.id);
+    console.log( onePost );
+    res.status( 200 ).json( onePost );
+  } catch ( err ) {
+    console.log( err );
+    res.status( 400 ).json({ err: err.message });
+  }
+});
+
 // Show route for all posts by single user ==> to add later
 
 // Create Route for one post

--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -47,16 +47,16 @@ router.post('/', async (req, res) => {
 });
 
 // Update route for posts
-// router.put( '/:id', async (req, res) => {
-//   try {
-//     const updatePost = await Post.findByIdAndUpdate( req.params.id, req.body );
-//     console.log(updatePost);
-//     res.status( 200 ).json( updatePost );
-//   } catch ( err ) {
-//     console.log( err );
-//     res.status( 400 ).json({ err: err.message });
-//   }
-// });
+router.put( '/:id', async (req, res) => {
+  try {
+    const updatePost = await Post.findByIdAndUpdate( req.params.id, req.body );
+    console.log(updatePost);
+    res.status( 200 ).json( updatePost );
+  } catch ( err ) {
+    console.log( err );
+    res.status( 400 ).json({ err: err.message });
+  }
+});
 
 // Delete route for one post
 // Need to add authentication permissions later


### PR DESCRIPTION
Show one and update routes added.

Post controller has the following functional routes tested via Postman:

1. Get index route for all posts (JSON testing for now)
2. Get route for one post
3. Post route for creating a new post
4. Put route for updating individual posts
5. Delete route for deleting individual posts

Not currently checking for login authentication on any routes.
User can be associated with a post by via foreign object key by using the _id of said user. 


